### PR TITLE
Add permission Checks for other mount points

### DIFF
--- a/qatp/base/init.sls
+++ b/qatp/base/init.sls
@@ -74,6 +74,21 @@ aws-cli:
     - directory 
     - mode: 777
 
+/mnt1:
+  file:
+    - directory 
+    - mode: 777
+    
+/mnt2:
+  file:
+    - directory 
+    - mode: 777
+    
+/mnt3:
+  file:
+    - directory 
+    - mode: 777
+
 fix_tty:
   cmd:
     - run


### PR DESCRIPTION
Add permission checks for /mn1, /mnt2, etc, this will help with support for m1.xlarge and should be harmless to other node types.
