### PR TITLE
Update install_ipa.sh

### DIFF
--- a/qatp/ipa/scripts/install_ipa.sh
+++ b/qatp/ipa/scripts/install_ipa.sh
@@ -4,7 +4,6 @@
 for attempt in `seq 0 1`; do
     ipa-client-install \
         --domain={{ pillar.ipa.client_domain }} \
-        --server={{ pillar.ipa.server}} \
         --realm={{ pillar.ipa.realm }} \
         -p builduser \
         -w "{{ pillar.ipa.client_password }}" \


### PR DESCRIPTION
I'm proposing the removal of specifying the server.  We have added DNS to our domain to auto select out of the two master servers (IPA1 and IPA3).   I have just tested this setting and it worked perfectly.   Feel free to test before implementing.
